### PR TITLE
Fix missing packages for build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN \
     # Install python (otherwise ansible will not work) \
     # Install aptitude, since ansible needs it (only apt-get is installed) \
     apt-get -y update && \
-    apt-get -y install python python-dev python-pip aptitude && \
+    apt-get -y install python python-dev python-pip aptitude libssl-dev sudo && \
     # Enable password-less sudo for all user (including the 'vagrant' user) \
     chmod u+w ${SUDOFILE} && \
     echo '%sudo   ALL=(ALL:ALL) NOPASSWD: ALL' >> ${SUDOFILE} && \


### PR DESCRIPTION
Your docker build has failed (https://hub.docker.com/r/allansimon/docker-dev-rust/builds/bkq98i6gsxpyrwyv5vt4eyy/) because of two missing packages : libssl-dev and sudo.

I tried to build your image on my local with the fix and it worked well.